### PR TITLE
Add a test script alias and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+logs
+*.log
+npm-debug.log*
+coverage
+.grunt
+node_modules
+.npm
+.node_repl_history

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # boxart
 
 Tools for building html games with React. Depended on by and documented at [boxart/boxart-boiler](https://github.com/boxart/boxart-boiler).
+
+## Local Development
+
+To work on boxart locally, you must have [Node](https://nodejs.org/) installed on your computer. After cloning this repository, run `npm install` (from the command prompt or terminal) to download boxart's package dependencies.
+
+To run the boxart unit test suite, use the `npm test` command; or (if [Grunt](http://gruntjs.com/) is [globally installed](http://gruntjs.com/getting-started#installing-the-cli) on your computer) run `grunt test-dev`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt test-dev"
   },
   "repository": {
     "type": "git",
@@ -32,6 +32,7 @@
     "babel-preset-react": "^6.5.0",
     "chai": "^3.5.0",
     "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
     "grunt-karma": "^0.12.2",
     "karma": "^0.13.22",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
This PR
- Adds a gitignore file to exclude node_modules & other npm-related files from the repository
- Installs grunt-cli locally so that `grunt` can be used by NPM scripts
- Aliases `grunt test-dev` to `npm test` to execute the test suite in karma (we will eventually want to make a single-run version for use with CI)
- Documents basic installation instructions in the readme
- Documents how to run the unit tests in the readme
