### PR TITLE
Add grunt publish task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,4 +2,5 @@ module.exports = function(grunt) {
   grunt.loadTasks('grunt');
 
   grunt.registerTask('test-dev', 'karma:dev');
+  grunt.registerTask('publish', ['clean', 'babel', 'publish-modules'])
 };

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Tools for building html games with React. Depended on by and documented at [boxa
 To work on boxart locally, you must have [Node](https://nodejs.org/) installed on your computer. After cloning this repository, run `npm install` (from the command prompt or terminal) to download boxart's package dependencies.
 
 To run the boxart unit test suite, use the `npm test` command; or (if [Grunt](http://gruntjs.com/) is [globally installed](http://gruntjs.com/getting-started#installing-the-cli) on your computer) run `grunt test-dev`.
+
+### Grunt Tasks
+
+#### test-dev
+
+`grunt test-dev` boots a test server with karma to run tests as changes to the source code or tests are made.
+
+#### publish
+
+`grunt publish` transpiles boxart's es2015 code to es5 and publishes boxart and its subpackages (e.g. boxart-stage) to npm.

--- a/grunt/grunt-babel.js
+++ b/grunt/grunt-babel.js
@@ -1,0 +1,14 @@
+module.exports = function(grunt) {
+  grunt.loadNpmTasks('grunt-babel');
+
+  grunt.config.set('babel', {
+    build: {
+      files: [{
+        cwd: 'src',
+        expand: true,
+        src: '*.js',
+        dest: 'lib',
+      }],
+    },
+  });
+};

--- a/grunt/grunt-contrib-clean.js
+++ b/grunt/grunt-contrib-clean.js
@@ -1,0 +1,7 @@
+module.exports = function(grunt) {
+  grunt.loadNpmTasks('grunt-contrib-clean');
+
+  grunt.config.set('clean', {
+    build: ['lib'],
+  });
+};

--- a/grunt/publish-modules.js
+++ b/grunt/publish-modules.js
@@ -1,0 +1,94 @@
+module.exports = function(grunt) {
+  var fs = require('fs');
+  var path = require('path');
+  var spawn = require('child_process').spawn;
+
+  function npmPublish(cwd) {
+    return new Promise(function(resolve, reject) {
+      if (grunt.option('dry-run')) {
+        grunt.log.write('spawn npm publish {cwd: ' + cwd +'}\n');
+        resolve();
+      }
+      else {
+        var child = spawn('npm', ['publish'], {
+          stdio: 'inherit',
+          cwd: path.resolve(cwd || ''),
+        });
+        child.on('error', reject);
+        child.on('exit', resolve);
+      }
+    });
+  }
+
+  function promisify(fn, ctx) {
+    return function() {
+      var args = [].slice.call(arguments);
+      return new Promise(function(resolve, reject) {
+        args.push(function(error, result) {
+          if (error) {
+            reject(error);
+          }
+          else if (arguments.length === 2) {
+            resolve(result);
+          }
+          else {
+            resolve([].slice.call(arguments, 1));
+          }
+        });
+        fn.apply(ctx, args);
+      });
+    };
+  }
+
+  grunt.registerTask('publish-modules', function() {
+    var done = this.async();
+
+    var readdir = promisify(fs.readdir, fs);
+    var readFile = promisify(fs.readFile, fs);
+    var writeFile = promisify(fs.writeFile, fs);
+
+    var version = readFile('package.json', 'utf8')
+    .then(JSON.parse)
+    .then(function(package) {return package.version;});
+    var packages = readdir('packages');
+
+    return Promise.all([packages, version])
+    // Update package versions to mirror boxart.
+    .then(function(values) {
+      var packages = values[0];
+      var version = values[1];
+      return Promise.all(packages.map(function(packageName) {
+        var subpackagePath = path.join('packages', packageName, 'package.json');
+        readFile(subpackagePath, 'utf8')
+        .then(JSON.parse)
+        .then(function(package) {
+          package.version = version;
+          package.peerDependencies.boxart = '^' + version;
+          return writeFile(subpackagePath, JSON.stringify(package, null, '  '), 'utf8');
+        });
+      }));
+    })
+    // Publish boxart itself.
+    .then(function() {
+      grunt.log.write('Publish boxart.\n');
+      return npmPublish();
+    })
+    // Publish boxart packages.
+    .then(function() {return packages;})
+    .then(function(packages) {
+      return packages.reduce(function(carry, packageName) {
+        return carry
+        .then(function() {
+          grunt.log.write('Publish ' + packageName + '.\n');
+          return npmPublish(path.join('packages', packageName));
+        });
+      }, Promise.resolve());
+    })
+    // All done. Say how many were published.
+    .then(function() {return packages;})
+    .then(function(packages) {
+      grunt.log.ok('Published ' + (1 + packages.length) + ' packages.');
+    })
+    .then(function() {done();}, done);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "boxart",
   "version": "0.0.0",
   "description": "Tools for building games in HTML.",
-  "main": "index.js",
+  "main": "lib/index.js",
+  "files": [
+    "src",
+    "lib"
+  ],
   "directories": {
     "test": "tests"
   },
@@ -24,6 +28,13 @@
     "url": "https://github.com/boxart/boxart/issues"
   },
   "homepage": "https://github.com/boxart/boxart#readme",
+  "dependencies": {
+    "react-addons-css-transition-group": "^15.0.2",
+    "react-addons-transition-group": "^15.0.2"
+  },
+  "peerDependencies": {
+    "react": "^15.0.2"
+  },
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-core": "^6.7.7",
@@ -32,7 +43,8 @@
     "babel-preset-react": "^6.5.0",
     "chai": "^3.5.0",
     "grunt": "^1.0.1",
-    "grunt-cli": "^1.2.0",
+    "grunt-babel": "^6.0.0",
+    "grunt-contrib-clean": "^1.0.0",
     "grunt-karma": "^0.12.2",
     "karma": "^0.13.22",
     "karma-chai": "^0.1.0",

--- a/packages/boxart-stage/README.md
+++ b/packages/boxart-stage/README.md
@@ -1,0 +1,3 @@
+# boxart-stage
+
+Tools for building html games with React. Depended on by and documented at [boxart/boxart-boiler](https://github.com/boxart/boxart-boiler).

--- a/packages/boxart-stage/index.js
+++ b/packages/boxart-stage/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  Stage: require('boxart/lib/stage'),
+  CSSStage: require('boxart/lib/css-stage'),
+  LinearStage: require('boxart/lib/linear-stage'),
+  LinearCSSStage: require('boxart/lib/linear-css-stage'),
+};

--- a/packages/boxart-stage/package.json
+++ b/packages/boxart-stage/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "boxart-stage",
+  "version": "0.0.0",
+  "description": "A boxart package exporting Stage elements",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boxart/boxart.git"
+  },
+  "keywords": [
+    "react",
+    "html",
+    "games"
+  ],
+  "author": "Michael \"Z\" Goddard <mzgoddard@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/boxart/boxart/issues"
+  },
+  "homepage": "https://github.com/boxart/boxart#readme",
+  "peerDependencies": {
+    "boxart": "^0.0.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  Stage: require('./stage'),
+  CSSStage: require('./css-stage'),
+  LinearStage: require('./linear-stage'),
+  LinearCSSStage: require('./linear-css-stage'),
+};


### PR DESCRIPTION
- Add grunt babel to transpile es2015 to es5 from src folder to lib
- Add grunt publish to clean lib, babel src to lib, and publish all
  packages
- Remove grunt-cli dependency, grunt-cli only benefits when installed
  globally
