### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) is a configuration file which can instruct code editors to automatically conform to certain whitespace styles, largely around newline, end of file and indentation consistency. Using an editorconfig here will for example make it so that editorconfig-aware code editors (which is either default or enabled via plugin) will apply EOL characters and select 2-space indentation consistently.

The settings selected were chosen to conform to the extant code.
