### PR TITLE
Add grunt watch task & ignore generated ES5 code (closes #12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ coverage
 node_modules
 .npm
 .node_repl_history
+
+# Generated ES5 code
+lib

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ To run the boxart unit test suite, use the `npm test` command; or (if [Grunt](ht
 
 `npm test` runs the test suite once in a captured Firefox browser instance and then exits.
 
+#### grunt babel
+
+`grunt babel` will run [babel](https://babeljs.io/) to create a `lib` directory of ES5 code compiled from this repository's ES2016 `src` directory.
+
+#### grunt watch
+
+`grunt watch` (or `grunt watch:babel`) will automatically re-run `grunt babel` whenever files in `src` change; this is useful if you have used [`npm link`](https://docs.npmjs.com/cli/link) to include a local copy of `boxart` in your application for development purposes.
+
 #### grunt publish
 
 `grunt publish` transpiles boxart's es2015 code to es5 and publishes boxart and its subpackages (e.g. boxart-stage) to npm.

--- a/grunt/grunt-contrib-watch.js
+++ b/grunt/grunt-contrib-watch.js
@@ -1,0 +1,10 @@
+module.exports = function(grunt) {
+  grunt.loadNpmTasks('grunt-contrib-watch');
+
+  grunt.config.set('watch', {
+    babel: {
+      files: ['src/**/*.js'],
+      tasks: ['babel:build']
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt": "^1.0.1",
     "grunt-babel": "^6.0.0",
     "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
     "karma": "^0.13.22",
     "karma-chai": "^0.1.0",
     "karma-firefox-launcher": "^0.1.7",


### PR DESCRIPTION
This resolves #12 by adding a development command to automatically re-build the library code whenever the source files change on disk.
