### PR TITLE
Fix unmounting Animateds

### DIFF
--- a/src/animated-agent.js
+++ b/src/animated-agent.js
@@ -264,9 +264,13 @@ export default class AnimatedAgent extends Component {
       // the same key it'll need to restart the animation. The animation is left
       // so any such new component will "cancel" it again giving it the rect to
       // continue with.
-      if (this.animations[key] && this.animations[key].cancel) {
-        this.animations[key].cancel();
-      }
+      const animation = this.animations[key];
+      this.soon()
+      .then(() => {
+        if (animation === this.animations[key] && animation.cancel) {
+          animation.cancel();
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Animateds when unmounted need to cancel their animation. But they
shouldn't do it immediately as if they are mounted right after
somewhere else on the page the interruption of the animation should
happen then allowing one animation to feed into the next.
