### PR TITLE
Add boxart-batch and react-batch packages

### DIFF
--- a/grunt/publish-modules.js
+++ b/grunt/publish-modules.js
@@ -63,7 +63,15 @@ module.exports = function(grunt) {
         .then(JSON.parse)
         .then(function(package) {
           package.version = version;
-          package.peerDependencies.boxart = '^' + version;
+          if (package.peerDependencies) {
+            package.peerDependencies.boxart = '^' + version;
+          }
+          if (package.dependencies) {
+            package.dependencies.boxart = '^' + version;
+            if (package.dependencies['boxart-batch']) {
+              package.dependencies['boxart-batch'] = '^' + version;
+            }
+          }
           return writeFile(subpackagePath, JSON.stringify(package, null, '  '), 'utf8');
         });
       }));

--- a/packages/boxart-batch/README.md
+++ b/packages/boxart-batch/README.md
@@ -1,0 +1,3 @@
+# boxart-batch
+
+Tools for building html games with React. Depended on by and documented at [boxart/boxart-boiler](https://github.com/boxart/boxart-boiler).

--- a/packages/boxart-batch/index.js
+++ b/packages/boxart-batch/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  Batch: require('boxart/lib/batch'),
+  BatchFactory: require('boxart/lib/batch-factory'),
+};

--- a/packages/boxart-batch/package.json
+++ b/packages/boxart-batch/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "boxart-batch",
+  "version": "0.0.0",
+  "description": "A boxart package exporting Batch elements",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boxart/boxart.git"
+  },
+  "keywords": [
+    "react",
+    "html",
+    "games"
+  ],
+  "author": "Michael \"Z\" Goddard <mzgoddard@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/boxart/boxart/issues"
+  },
+  "homepage": "https://github.com/boxart/boxart#readme",
+  "peerDependencies": {
+    "boxart": "^0.0.0"
+  }
+}

--- a/packages/react-batch/README.md
+++ b/packages/react-batch/README.md
@@ -1,0 +1,3 @@
+# react-batch
+
+Exports [boxart](github.com/boxart/boxart)'s Batch and BatchFactory. If using more of boxart use boxart-batch instead. Tools for building html games with React.

--- a/packages/react-batch/index.js
+++ b/packages/react-batch/index.js
@@ -1,0 +1,1 @@
+module.exports = require('boxart-batch');

--- a/packages/react-batch/package.json
+++ b/packages/react-batch/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "react-batch",
+  "version": "0.0.0",
+  "description": "Build batches of items with boxart batch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boxart/boxart.git"
+  },
+  "keywords": [
+    "react",
+    "html",
+    "games"
+  ],
+  "author": "Michael \"Z\" Goddard <mzgoddard@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/boxart/boxart/issues"
+  },
+  "homepage": "https://github.com/boxart/boxart#readme",
+  "dependencies": {
+    "boxart": "^0.0.0",
+    "boxart-batch": "^0.0.0",
+  }
+}


### PR DESCRIPTION
boxart-batch is like the other boxart packages exposing specific classes instead of the full library.

react-batch wraps boxart and boxart-batch dependencies for projects that just want batch.
