### PR TITLE
Silence uncaught errors in timers given to AnimatedAgent

### DIFF
--- a/src/animated-agent.js
+++ b/src/animated-agent.js
@@ -268,6 +268,9 @@ export default class AnimatedAgent extends Component {
       this.soon()
       .then(() => {
         if (animation === this.animations[key] && animation.cancel) {
+          if (animation.then) {
+            animation.then(null, () => {});
+          }
           animation.cancel();
         }
       });
@@ -347,8 +350,12 @@ export default class AnimatedAgent extends Component {
         // stored rect or by canceling a current animation and using its
         // returned value.
         let lastRect;
-        if (this.animations[key] && this.animations[key].cancel) {
-          lastRect = this.animations[key].cancel();
+        const oldAnimation = this.animations[key];
+        if (oldAnimation && oldAnimation.cancel) {
+          if (oldAnimation.then) {
+            oldAnimation.then(function() {}, function() {});
+          }
+          lastRect = oldAnimation.cancel();
         }
         if (!lastRect) {
           lastRect = this.rects[key].clone();

--- a/src/animated-agent.js
+++ b/src/animated-agent.js
@@ -267,7 +267,10 @@ export default class AnimatedAgent extends Component {
       const animation = this.animations[key];
       this.soon()
       .then(() => {
-        if (animation === this.animations[key] && animation.cancel) {
+        if (
+          animation === this.animations[key] &&
+          animation && animation.cancel
+        ) {
           if (animation.then) {
             animation.then(null, () => {});
           }

--- a/src/animated-timer.js
+++ b/src/animated-timer.js
@@ -60,6 +60,10 @@ export default class AnimatedTimer {
       if (this.run !== run) {
         throw new Error('Timer canceled');
       }
+    })
+    .catch(error => {
+      this._reject(error);
+      throw error;
     });
   }
 

--- a/tests/animated-agent.js
+++ b/tests/animated-agent.js
@@ -8,6 +8,11 @@ describe('AnimatedAgent', function() {
 
   let root;
 
+  const resolveThen = () => {
+    const p = Promise.resolve();
+    return p.then.bind(p);
+  };
+
   before(function() {
     root = document.createElement('div');
     document.body.appendChild(root);
@@ -94,7 +99,7 @@ describe('AnimatedAgent', function() {
   it('cancels animation when Animated did update', function() {
     const spy = sinon.spy();
     const stub = sinon.stub();
-    stub.returns({cancel: spy});
+    stub.returns({cancel: spy, then: resolveThen()});
     render(<AnimatedAgent><div>
       <Animated key="key" animateKey="key" animate={stub}>
         <div></div>

--- a/tests/animated-agent.js
+++ b/tests/animated-agent.js
@@ -9,7 +9,8 @@ describe('AnimatedAgent', function() {
   let root;
 
   const resolveThen = () => {
-    const p = Promise.resolve();
+    const p = new Promise(requestAnimationFrame)
+    .then(() => new Promise(requestAnimationFrame));
     return p.then.bind(p);
   };
 


### PR DESCRIPTION
Errors are still passed normally in Timers so that apps can listen for
them, the normal uncaught error error will just be silent in. Probably
will revisit and consider a way to exclude this behaviour in dev but
the likely case is that the uncaught error error would occur very
frequently and restrict use of dev tools that report it.
