### PR TITLE
Export Batch and BatchFactory in boxart's index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import Animated from './animated';
 import AnimatedAgent from './animated-agent';
 import AnimatedRect from './animated-rect';
+import Batch from './batch';
+import BatchFactory from './batch-factory';
 import Stage from './stage';
 import CSSStage from './css-stage';
 import LinearStage from './linear-stage';
@@ -10,6 +12,8 @@ module.exports = {
   Animated,
   AnimatedAgent,
   AnimatedRect,
+  Batch,
+  BatchFactory,
   Stage,
   CSSStage,
   LinearStage,


### PR DESCRIPTION
Batch and BatchFactory were not previously added to index when they were added to BoxArt. This corrects that omission.
