### PR TITLE
Move style storage and logic into Animated

### DIFF
--- a/src/animated-agent-base.js
+++ b/src/animated-agent-base.js
@@ -98,57 +98,20 @@ export default class AnimatedAgentBase {
     }
   }
 
-  removeAnimatedStyle(animated, animatedEl) {
-    // Return an animated element to the style an animation replaced. This
-    // should return the element to how it was before the animation was played.
-    // This is used at times to return the element to the non animated state to
-    // query the DOM's layout. After use, the style is returned to that of the
-    // any current animation so a user never sees the change.
-    const animatedKey = animated.getAnimateKey();
-    if (!this.replacedStyles[animatedKey]) {
-      return;
-    }
-    Object.assign(animatedEl.style, this.replacedStyles[animatedKey]);
-    this.replacedStyles[animatedKey] = null;
-  }
-
   setReplaceStyle(animated, animatedEl, style) {
-    // Set the style of an animated element and store the style that was
-    // replaced. When style has new keys, record the replaced style. When style
-    // no longer has keys that have replaced values recorded, return those
-    // replaced values.
-    const animatedKey = animated.getAnimateKey();
-    if (!this.replacedStyles[animatedKey]) {
-      this.replacedStyles[animatedKey] = {};
-    }
-    const replaced = this.replacedStyles[animatedKey];
-    this.styles[animatedKey] = style;
-    for (const key in replaced) {
-      if (!style || !style.hasOwnProperty(key)) {
-        animatedEl.style[key] = replaced[key];
-        delete replaced[key];
-      }
-    }
-    // The end of an animation sets the style to a null object, removing any
-    // styling the animation had previously applied.
-    if (!style) {
-      this.replacedStyles[animatedKey] = null;
-      return null;
-    }
-    for (const key in style) {
-      if (!replaced.hasOwnProperty(key)) {
-        replaced[key] = animatedEl.style[key];
-      }
-    }
-    Object.assign(animatedEl.style, style);
-    return replaced;
+    return animated.replaceStyle(style);
   }
 
   setAnimatedStyle(animated, animatedEl, style) {
-    // Set the style of an animated element.
-    const animatedKey = animated.getAnimateKey();
-    this.styles[animatedKey] = style;
-    Object.assign(animatedEl.style, style);
+    return animated.setStyle(style);
+  }
+
+  restoreAnimatedStyle(animated, animatedEl) {
+    return animated.restoreStyle();
+  }
+
+  removeAnimatedStyle(animated, animatedEl) {
+    return animated.restoreStyle();
   }
 
   timer(fn) {
@@ -398,7 +361,7 @@ export default class AnimatedAgentBase {
       for (const key in this.animateds) {
         const animated = this.animateds[key];
         if (animated) {
-          this.removeAnimatedStyle(animated, findDOMNode(animated));
+          animated.restoreAll();
         }
       }
       // Get the new rects for all Animateds.
@@ -415,7 +378,7 @@ export default class AnimatedAgentBase {
       for (const key in this.animateds) {
         const animated = this.animateds[key];
         if (animated) {
-          this.setAnimatedStyle(animated, findDOMNode(animated), this.styles[key]);
+          animated.replaceAll();
         }
       }
     });

--- a/src/animated-agent.js
+++ b/src/animated-agent.js
@@ -48,16 +48,20 @@ export default class AnimatedAgent extends Component {
     this.base.willUnmount();
   }
 
-  removeAnimatedStyle(animated, animatedEl) {
-    return this.base.removeAnimatedStyle(animated, animatedEl);
-  }
-
   setReplaceStyle(animated, animatedEl, style) {
     return this.base.setReplaceStyle(animated, animatedEl, style);
   }
 
   setAnimatedStyle(animated, animatedEl, style) {
     return this.base.setAnimatedStyle(animated, animatedEl, style);
+  }
+
+  restoreAnimatedStyle(animated, animatedEl) {
+    return this.base.restoreAnimatedStyle(animated, animatedEl);
+  }
+
+  removeAnimatedStyle(animated, animatedEl) {
+    return this.base.removeAnimatedStyle(animated, animatedEl);
   }
 
   animateFrom(animated, animatedEl, lastRect, rect, duration) {

--- a/src/animated-callback-options.js
+++ b/src/animated-callback-options.js
@@ -32,16 +32,21 @@ export default class AnimatedCallbackOptions {
     return this.agent.animateFrom(this.animated, this.animatedEl, lastRect, rect, duration);
   }
 
-  removeStyle() {
-    this.agent.removeAnimatedStyle(this.animated, this.animatedEl);
-  }
-
   replaceStyle(style) {
-    this.agent.setReplaceStyle(this.animated, this.animatedEl, style);
+    this.animated.replaceStyle(style);
   }
 
   setStyle(style) {
-    this.agent.setAnimatedStyle(this.animated, this.animatedEl, style);
+    this.animated.setStyle(style);
+  }
+
+  /* deprecated */
+  removeStyle() {
+    this.animated.restoreStyle();
+  }
+
+  restoreStyle() {
+    this.animated.restoreStyle();
   }
 
   timer(fn) {

--- a/src/animated.js
+++ b/src/animated.js
@@ -4,6 +4,8 @@ import {findDOMNode} from 'react-dom';
 import AnimatedAgentBase from './animated-agent-base';
 import AnimatedRect from './animated-rect';
 
+import AnimatedStyle from './util/animated-style';
+
 const globalAgent = AnimatedAgentBase.globalAgent;
 
 /**
@@ -79,7 +81,15 @@ const globalAgent = AnimatedAgentBase.globalAgent;
  * and will be updated if for example the window resized.
  */
 export default class Animated extends Component {
+  constructor(...args) {
+    super(...args);
+    this.replacedStyle = {};
+    this.style = {};
+    this.element = null;
+  }
+
   componentDidMount() {
+    this.element = findDOMNode(this);
     this.agent().mountAnimated(this);
     this.agent().updateAnimated(this);
   }
@@ -93,6 +103,7 @@ export default class Animated extends Component {
   }
 
   componentWillUnmount() {
+    this.element = null;
     this.agent().unmountAnimated(this);
   }
 
@@ -113,6 +124,34 @@ export default class Animated extends Component {
       return this.props.animate(options);
     }
     return options.animateFromLast(0.3);
+  }
+
+  replaceStyle(style) {
+    const el = this.element;
+    const replacedCopy = this.replacedStyle;
+    const styleCopy = this.style;
+    return AnimatedStyle.replaceStyle(this, el, style, replacedCopy, styleCopy);
+  }
+
+  setStyle(style) {
+    this.style = style;
+    const el = this.element;
+    return AnimatedStyle.setStyle(this, el, style);
+  }
+
+  restoreStyle() {
+    const el = this.element;
+    return AnimatedStyle.restoreStyle(this, el, this.replacedStyle);
+  }
+
+  replaceAll() {
+    const el = this.element;
+    AnimatedStyle.replaceStyle(this, el, this.style, this.replacedStyle);
+  }
+
+  restoreAll() {
+    const el = this.element;
+    AnimatedStyle.restoreStyle(this, el);
   }
 
   render() {

--- a/src/util/animated-style.js
+++ b/src/util/animated-style.js
@@ -1,0 +1,46 @@
+export default {
+  replaceStyle(animated, animatedEl, style, replaced, styleCopy) {
+    // Set the style of an animated element and store the style that was
+    // replaced. When style has new keys, record the replaced style. When style
+    // no longer has keys that have replaced values recorded, return those
+    // replaced values.
+    if (styleCopy) {
+      Object.assign(styleCopy, style);
+    }
+    for (const key in replaced) {
+      if (!style || !style.hasOwnProperty(key)) {
+        animatedEl.style[key] = replaced[key];
+        delete replaced[key];
+      }
+    }
+    // The end of an animation sets the style to a null object, removing any
+    // styling the animation had previously applied.
+    if (!style) {
+      return null;
+    }
+    for (const key in style) {
+      if (!replaced.hasOwnProperty(key)) {
+        replaced[key] = animatedEl.style[key];
+      }
+    }
+    Object.assign(animatedEl.style, style);
+    return replaced;
+  },
+
+  setStyle(animated, animatedEl, style, styleCopy) {
+    // Set the style of an animated element.
+    if (styleCopy) {
+      Object.assign(styleCopy, style);
+    }
+    Object.assign(animatedEl.style, style);
+  },
+
+  restoreStyle(animated, animatedEl, replaced) {
+    // Return an animated element to the style an animation replaced. This
+    // should return the element to how it was before the animation was played.
+    // This is used at times to return the element to the non animated state to
+    // query the DOM's layout. After use, the style is returned to that of the
+    // any current animation so a user never sees the change.
+    this.replaceStyle(animated, animatedEl, null, replaced, null);
+  },
+};


### PR DESCRIPTION
AnimatedAgent is doing too much. Move the storage of replaced style into
Animated. In Animated that data will be cleaned up with the element
instance when its unmounted instead of needing to worry about adding
special logic to Agent. This also provides a more clear cut of
responsibilities for handling more of the rendering changes an animation
makes like adding methods that handle attributes.
- Add Animated.restoreStyle, performs the replaceStyle with no
  arguments logic providing a clearer name.
