### PR TITLE
Don't pass items or itemKey to the underlying tag for Batch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxart",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Tools for building games in HTML.",
   "main": "lib/index.js",
   "files": [

--- a/src/batch.js
+++ b/src/batch.js
@@ -110,9 +110,12 @@ export default class Batch extends Component {
 
   render() {
     const children = this.state.items;
-    const props = this.props;
-    const Tag = props.component || 'div';
-    return (<Tag {...props}>{children}</Tag>);
+    // Need to remove items and itemKey before passing to the underlying tag.
+    const componentProps = Object.assign({}, this.props);
+    delete componentProps.items;
+    delete componentProps.itemKey;
+    const Tag = this.props.component || 'div';
+    return (<Tag {...componentProps}>{children}</Tag>);
   }
 }
 


### PR DESCRIPTION
Passing items and itemKey to the tag brings up a React warning since it
doesn't know what to do with them. If in the future it did use them them
we'd likely get undefined behaviour.
