### PR TITLE
Set transition meta didEnter if animation is not default

### DIFF
--- a/packages/boxart/src/level2/preact-element-transition.js
+++ b/packages/boxart/src/level2/preact-element-transition.js
@@ -26,6 +26,13 @@ class PreactElementTransition extends BaseTransition {
     if (this.alive[id]) {
       this.alive[id](true);
     }
+    if (animation !== '' || animation !== 'default') {
+      const branch = this.tree.element(id);
+      if (branch) {
+        const meta = branch.meta(id);
+        meta.didEnter = true;
+      }
+    }
   }
 
   onStateEnd(type, id, animation) {

--- a/packages/boxart/src/level2/react-element-transition.js
+++ b/packages/boxart/src/level2/react-element-transition.js
@@ -26,6 +26,13 @@ class ReactElementTransition extends BaseTransition {
     if (this.alive[id]) {
       this.alive[id](true);
     }
+    if (animation !== '' || animation !== 'default') {
+      const branch = this.tree.element(id);
+      if (branch) {
+        const meta = branch.meta(id);
+        meta.didEnter = true;
+      }
+    }
   }
 
   onStateEnd(type, id, animation) {


### PR DESCRIPTION
Keep the element transitions from overwriting the original animation state if
that state is not default.